### PR TITLE
Ipv4 only server patch

### DIFF
--- a/server.py
+++ b/server.py
@@ -66,9 +66,10 @@ def main():
 		config['dbSupport'] = True
 	try:
 		socket.inet_pton(socket.AF_INET6, config['ip'])
-	except OSError:
-		server = socketserver.TCPServer((config['ip'], config['port']), kmsServer)
-	except IOError:
+	except (
+			OSError,  # input address is ipv4
+			IOError,  # ipv6 is unavailable
+	):
 		server = socketserver.TCPServer((config['ip'], config['port']), kmsServer)
 	else:
 		server = V6Server((config['ip'], config['port']), kmsServer)

--- a/server.py
+++ b/server.py
@@ -68,6 +68,8 @@ def main():
 		socket.inet_pton(socket.AF_INET6, config['ip'])
 	except OSError:
 		server = socketserver.TCPServer((config['ip'], config['port']), kmsServer)
+	except IOError:
+		server = socketserver.TCPServer((config['ip'], config['port']), kmsServer)
 	else:
 		server = V6Server((config['ip'], config['port']), kmsServer)
 	server.timeout = 5


### PR DESCRIPTION
Add proper error handling for ipv4 socket creation when ipv6 is not available on the server.